### PR TITLE
Fix startup script monitor setting

### DIFF
--- a/profiles/gomez/bin/startup.sh
+++ b/profiles/gomez/bin/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -euo pipefail
 
-xrandr --output HDMI-1 --off --output eDP-1 --primaryy --mode 1920x1080 --pos 0x0 --rotate normal
+xrandr --output HDMI-1 --off --output eDP-1 --primary --mode 1920x1080 --pos 0x0 --rotate normal
 wait "$!"
 sleep 5
 


### PR DESCRIPTION
## Summary
- fix monitor flag typo in `profiles/gomez/bin/startup.sh`

## Testing
- `grep -n -- '--primary' profiles/gomez/bin/startup.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c2f7394ec8328bd45d25f7afd0c86